### PR TITLE
lodash bumped to 4.17.11

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   "author": "patrick@updater.com",
   "license": "MIT",
   "dependencies": {
-    "lodash": "3.10.0"
+    "lodash": "4.17.11"
   },
   "devDependencies": {
     "babel": "5.6.23",


### PR DESCRIPTION
lodash node module before 4.17.5 suffers from a Modification of Assumed-Immutable Data (MAID) vulnerability

https://nvd.nist.gov/vuln/detail/CVE-2018-3721