### PR TITLE
Fail globally

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@outlinerisk/jasmine-fail-hardcore",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Allow Jasmine tests to \"fail-fast\", exiting on the first failure instead of running all tests no matter what. ",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,10 +1,10 @@
 {
-  "name": "jasmine-fail-fast",
+  "name": "@outlinerisk/jasmine-fail-hardcore",
   "version": "2.0.0",
   "description": "Allow Jasmine tests to \"fail-fast\", exiting on the first failure instead of running all tests no matter what. ",
   "repository": {
     "type": "git",
-    "url": "git://github.com/Updater/jasmine-fail-fast.git"
+    "url": "git://github.com/outline-insurance/jasmine-fail-hardcore.git"
   },
   "main": "dist/jasmine-fail-fast.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@outlinerisk/jasmine-fail-hardcore",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Allow Jasmine tests to \"fail-fast\", exiting on the first failure instead of running all tests no matter what. ",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@outlinerisk/jasmine-fail-hardcore",
-  "version": "2.0.0",
+  "version": "0.1.0",
   "description": "Allow Jasmine tests to \"fail-fast\", exiting on the first failure instead of running all tests no matter what. ",
   "repository": {
     "type": "git",

--- a/src/index.js
+++ b/src/index.js
@@ -54,7 +54,7 @@ export function xEverything() {
       let test = it.apply(null, args);
       test.markedPending = true
       test.result.pendingReason = 'failfast'
-      return suite;
+      return test;
     });
 }
 

--- a/src/index.js
+++ b/src/index.js
@@ -2,17 +2,33 @@ import _ from 'lodash';
 
 let refs;
 
+function failingFast() {
+  if (!process.env.FAIL_FAST) return false
+  return fs.existsSync('__jasmine-is-failing-fast')
+}
+
+function writeFailingStateToDisk() {
+  fs.writeFileSync('__jasmine-is-failing-fast', 'true')
+}
+
+export function cleanUp() {
+  if (failingFast()) fs.unlink('__jasmine-is-failing-fast', () => {})
+}
+
 // Jasmine doesn't yet have an option to fail fast. This "reporter" is a workaround for the time
 // being, making Jasmine essentially skip all tests after the first failure.
 // https://github.com/jasmine/jasmine/issues/414
 // https://github.com/juliemr/minijasminenode/issues/20
-export function init() {
+export function init(hardcore = false) {
   refs = getSpecReferences();
+
+  if (hardcore && failingFast()) disableSpecs(refs)
 
   return {
     specDone(result) {
       if (result.status === 'failed') {
         disableSpecs(refs);
+        if (hardcore) writeFailingStateToDisk()
       }
     }
   };

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,5 @@
 import _ from 'lodash';
+import fs from 'fs';
 
 let refs;
 
@@ -22,7 +23,7 @@ export function cleanUp() {
 export function init(hardcore = false) {
   refs = getSpecReferences();
 
-  if (hardcore && failingFast()) disableSpecs(refs)
+  if (hardcore && failingFast()) xEverything(refs)
 
   return {
     specDone(result) {
@@ -32,6 +33,29 @@ export function init(hardcore = false) {
       }
     }
   };
+}
+
+/**
+ * Turn every call to describe into a (skipped) xdescribe, and same for it/xit.
+ *
+ * @return void
+ */
+export function xEverything() {
+  jasmine.getEnv().describe = _.wrap(jasmine.getEnv().describe,
+    (describe, ...args) => {
+      let suite = describe.apply(null, args);
+      suite.markedPending = true
+      suite.result.pendingReason = 'failfast'
+      return suite;
+    });
+
+  jasmine.getEnv().it = _.wrap(jasmine.getEnv().it,
+    (it, ...args) => {
+      let test = it.apply(null, args);
+      test.markedPending = true
+      test.result.pendingReason = 'failfast'
+      return suite;
+    });
 }
 
 /**


### PR DESCRIPTION
This PR adds a `hardcore = true` to the original `jasmineFailFast.init()` function.

When a test fails in "hardcore" mode, we write a file `__jasmine-is-failing-fast` to disk. Any later test suites which spin up and enable hardcore FailFast will see this file, and skip all of the tests in the suite.

Thus achieving the goal of --failFast actually... failing.