### PR TITLE
Replace lodash with lodash.wrap

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   "author": "pmowrer@gmail.com",
   "license": "MIT",
   "dependencies": {
-    "lodash": "^4.17.15"
+    "lodash.wrap": "^4.1.1"
   },
   "devDependencies": {
     "babel": "5.6.23",

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,4 @@
-import _ from 'lodash';
+import wrap from 'lodash.wrap';
 
 let refs;
 
@@ -34,7 +34,7 @@ export function getSpecReferences() {
   };
 
   // Wrap jasmine's describe function to gather references to all suites.
-  jasmine.getEnv().describe = _.wrap(jasmine.getEnv().describe,
+  jasmine.getEnv().describe = wrap(jasmine.getEnv().describe,
     (describe, ...args) => {
       let suite = describe.apply(null, args);
       suites.push(suite);

--- a/yarn.lock
+++ b/yarn.lock
@@ -3379,6 +3379,11 @@ lodash.without@~4.4.0:
   resolved "https://registry.yarnpkg.com/lodash.without/-/lodash.without-4.4.0.tgz#3cd4574a00b67bae373a94b748772640507b7aac"
   integrity sha1-PNRXSgC2e643OpS3SHcmQFB7eqw=
 
+lodash.wrap@^4.1.1:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/lodash.wrap/-/lodash.wrap-4.1.1.tgz#9c3770947a821ec6978a93571e1a6179afcd7fc8"
+  integrity sha512-zOvgaTFh+7jBC80FKyoOwMyi8VF3LWAWuakrSXFVTIZAmrJEAYiu7lqwJYDhwh6l5wXuF5aGlzTBymvD+1q6LA==
+
 lodash@^3.10.0, lodash@^3.2.0, lodash@^3.9.3:
   version "3.10.1"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-3.10.1.tgz#5bf45e8e49ba4189e17d482789dfd15bd140b7b6"


### PR DESCRIPTION
Reduces the size of the dependency when installing/using it, by directly using `lodash.wrap` instead of loading the whole library. Also only leaves you on the hook for vulnerabilities of a single lodash util rather than all of them